### PR TITLE
feat: add gcc to environment.systemPackages

### DIFF
--- a/src/apps/programming-language/c-and-c++/default.nix
+++ b/src/apps/programming-language/c-and-c++/default.nix
@@ -1,0 +1,3 @@
+{ pkgs, ... }: {
+	environment.systemPackages = with pkgs; [ gcc ];
+}


### PR DESCRIPTION
Adds gcc to the environment.systemPackages for C and C++ applications.
