### PR TITLE
feat(helix): add gopls and enable go support

### DIFF
--- a/home-manager/src/configs/helix/default.nix
+++ b/home-manager/src/configs/helix/default.nix
@@ -1,59 +1,22 @@
-{ pkgs, lib, ... }: {
+{ pkgs, lib, ... }:
+let
+  go = import ./lsp/go.nix { };
+in
+{
   programs.helix = {
     enable = true;
     defaultEditor = false;
     ignores = [ ];
     languages = {
       language = [
-        {
-          name = "go";
-          auto-format = true;
-          roots = [ "go.mod" "go.sum" "go.work" ];
-          comment-token = "//";
-          block-comment-tokens = {
-            start = "/*";
-            end = "*/";
-          };
-          language-servers = [ "gopls" ];
-          indent = {
-            tab-width = 2;
-            unit = " ";
-          };
-        }
+        go.language
       ];
       language-server = {
-        gopls = {
-          command = "gopls";
-          config = {
-            gofumpt = true;
-            local = "goimports";
-            semanticTokens = true;
-            staticcheck = true;
-            verboseOutput = true;
-            analyses = {
-              fieldalignment = true;
-              nilness = true;
-              unusedparams = true;
-              unusedwrite = true;
-              useany = true;
-            };
-            usePlaceholders = true;
-            completeUnimported = true;
-            hints = {
-              assignVariableType = true;
-              compositeLiteralFields = true;
-              compositeLiteralTypes = true;
-              constantValues = true;
-              functionTypeParameters = true;
-              parameterNames = true;
-              rangeVariableTypes = true;
-            };
-          };
-        };
+        gopls = go.server;
       };
     };
     settings = {
-      theme = "base16";
+      theme = "dark_plus";
       editor = {
         line-number = "absolute";
         lsp = {

--- a/home-manager/src/configs/helix/lsp/go.nix
+++ b/home-manager/src/configs/helix/lsp/go.nix
@@ -1,0 +1,45 @@
+{ ... }: {
+  language = {
+    name = "go";
+    auto-format = true;
+    roots = [ "go.mod" "go.sum" "go.work" ];
+    comment-token = "//";
+    block-comment-tokens = {
+      start = "/*";
+      end = "*/";
+    };
+    language-servers = [ "gopls" ];
+    indent = {
+      tab-width = 2;
+      unit = " ";
+    };
+  };
+  server = {
+    command = "gopls";
+    config = {
+      gofumpt = true;
+      local = "goimports";
+      semanticTokens = true;
+      staticcheck = true;
+      verboseOutput = true;
+      analyses = {
+        fieldalignment = true;
+        nilness = true;
+        unusedparams = true;
+        unusedwrite = true;
+        useany = true;
+      };
+      usePlaceholders = true;
+      completeUnimported = true;
+      hints = {
+        assignVariableType = true;
+        compositeLiteralFields = true;
+        compositeLiteralTypes = true;
+        constantValues = true;
+        functionTypeParameters = true;
+        parameterNames = true;
+        rangeVariableTypes = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
This commit adds support for the Go programming language to Helix by installing the gopls language server and necessary configurations.

Additionally, the default Helix theme has been updated to "dark_plus" for improved readability.
