### PR TITLE
feat(programming-language): add js-and-ts support

### DIFF
--- a/src/apps/programming-language/js-and-ts/default.nix
+++ b/src/apps/programming-language/js-and-ts/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib, ... }:
+let
+  isEnable = true;
+in
+lib.mkIf (isEnable) rec {
+  environment.systemPackages = with pkgs; [
+    nodejs
+    typescript-language-server
+    bun
+  ];
+}


### PR DESCRIPTION
This commit adds support for JavaScript and TypeScript to the programming-language app.

It includes the following changes:

- Adds a new default.nix file to the js-and-ts folder.
- Adds the nodejs, typescript-language-server, and bun packages to the systemPackages array.
