### PR TITLE
docs(go): add default.nix configuration file

### DIFF
--- a/src/apps/programming-language/go/default.nix
+++ b/src/apps/programming-language/go/default.nix
@@ -1,4 +1,8 @@
-{ config, pkgs, ... }: rec {
+{ config, pkgs, lib, ... }:
+let
+  isEnable = true;
+in
+lib.mkIf (isEnable) rec {
   environment.systemPackages = with  pkgs; [
     go
   ];


### PR DESCRIPTION
Adds a default.nix configuration file for the Go programming language. This file includes the necessary settings to enable Go development on the system.
