### PR TITLE
feat: enable gcc package

### DIFF
--- a/src/apps/programming-language/c-and-c++/default.nix
+++ b/src/apps/programming-language/c-and-c++/default.nix
@@ -1,3 +1,7 @@
-{ pkgs, ... }: {
-	environment.systemPackages = with pkgs; [ gcc ];
+{ pkgs, lib, ... }:
+let
+  isEnable = true;
+in
+lib.mkIf (isEnable) rec {
+  environment.systemPackages = with pkgs; [ gcc ];
 }


### PR DESCRIPTION
Enable gcc package for C and C++ programming language in the default configuration.
