### PR TITLE
feat(java,kubernetes): add support for java and kubernetes

### DIFF
--- a/src/apps/programming-language/java/default.nix
+++ b/src/apps/programming-language/java/default.nix
@@ -1,0 +1,9 @@
+{ pkgs, lib,...}:
+let
+  isEnable = true;
+in lib.mkIf (isEnable) {
+  environment.systemPackages = with pkgs; [
+    jdt-language-server
+    spring-boot-cli
+  ];
+}

--- a/src/apps/programming-language/kubernetes/default.nix
+++ b/src/apps/programming-language/kubernetes/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, lib,...}:
+let
+  isEnable = true;
+in lib.mkIf (isEnable) {
+  environment.systemPackages = with pkgs; [
+    helm_ls
+  ];
+}


### PR DESCRIPTION
This commit adds support for the Java and Kubernetes programming languages to the development environment.
- Adds the Java Development Kit (JDK) Language Server to enable Java syntax highlighting, autocompletion, and other IDE features.
- Adds the Spring Boot CLI to enable easy development and debugging of Spring Boot applications.
- Adds Helm Language Server (Helm LS) to enable autocompletion, syntax checking, and linting for Helm charts.
