### PR TITLE
feat: use earlyoom instead of systemd-oomd

### DIFF
--- a/src/systems/memory/default.nix
+++ b/src/systems/memory/default.nix
@@ -18,6 +18,7 @@
     freeSwapThreshold = 30; # Minimum free swap space (in percent) before sending SIGTERM.
     extraArgs = [
       "-g"
+      "-r 3" # report memory each 3s
     ];
   };
 }

--- a/src/systems/memory/default.nix
+++ b/src/systems/memory/default.nix
@@ -8,4 +8,13 @@
     memoryPercent = 100;
   };
   services.zram-generator.enable = true;
+  systemd.oomd.enable = false;
+  services.earlyoom = {
+    enable = true;
+    enableNotifications = true;
+    enableDebugInfo = true;
+    freeMemThreshold = 30; # Minimum available memory (in percent).
+    freeSwapThreshold = 30; # Minimum free swap space (in percent) before sending SIGTERM.
+    extraArgs = [];
+  };
 }

--- a/src/systems/memory/default.nix
+++ b/src/systems/memory/default.nix
@@ -1,4 +1,5 @@
-{ ... }: {
+{ ... }:
+{
   zramSwap = {
     enable = true;
     priority = -1; # lower value is high priority
@@ -15,6 +16,8 @@
     enableDebugInfo = true;
     freeMemThreshold = 30; # Minimum available memory (in percent).
     freeSwapThreshold = 30; # Minimum free swap space (in percent) before sending SIGTERM.
-    extraArgs = [];
+    extraArgs = [
+      "-g"
+    ];
   };
 }

--- a/src/systems/network/default.nix
+++ b/src/systems/network/default.nix
@@ -60,15 +60,16 @@
   networking.networkmanager.enable = false;
 
   networking.firewall = {
-    enable = false;
+    enable = true;
     allowedTCPPorts = [ ];
     allowedTCPPortRanges = [ ];
     allowedUDPPorts = [ ];
     allowedUDPPortRanges = [
+      # Chromecast client-to-control communication
       {
         from = 32768;
         to = 61000;
-      } # Chromecast client-to-control communication
+      }
     ];
   };
 }


### PR DESCRIPTION
- **feat(memory): enable earlyoom service**
- **chore(zram): enable debug logging for earlyoom**
- **feat(memory): add reporting memory each 3s**
- **chore(networking): enable firewall and allow chromecast udp ports**
