### PR TITLE
feat(helix): add keybinding to copy buffer path

### DIFF
--- a/home-manager/src/configs/helix/keys.nix
+++ b/home-manager/src/configs/helix/keys.nix
@@ -10,8 +10,11 @@
     A-z = ":toggle-option soft-wrap.enable";
     C-q = ":buffer-close";
     A-ret = [ ":run-shell-command basename $(pwd)" ];
-    C-ret = [ ":run-shell-command echo \"%sh{git blame -L %{cursor_line},+1 %{buffer_name} | cut -d' ' -f1-8}\"" ];
+    C-ret = [
+      ":run-shell-command echo \"%sh{git blame -L %{cursor_line},+1 %{buffer_name} | cut -d' ' -f1-8}\""
+    ];
     A-g = ":run-shell-command git difftool -d";
+    A-space = ":run-shell-command echo -n \"%{buffer_name}\" | sed \"s@~/@@g\" | sed \"s@$PWD@@g\" | wl-copy && echo \"Path copied!\"";
   };
   select = { };
 }


### PR DESCRIPTION
Adds `A-space` to copy the current buffer's path to the clipboard.
It removes `~/` and `$PWD` prefixes for cleaner paths.
