### PR TITLE
chore(helix): update keybindings and commands

### DIFF
--- a/home-manager/src/configs/helix/keys.nix
+++ b/home-manager/src/configs/helix/keys.nix
@@ -1,20 +1,24 @@
 { ... }:
 {
   normal = {
-    w = ":u";
-    f = ":format";
+    w = [ ":u" ];
+    f = [ ":format" ];
     A-r = [
       ":reload-all"
       ":lsp-restart"
     ];
-    A-z = ":toggle-option soft-wrap.enable";
-    C-q = ":buffer-close";
+    A-z = [ ":toggle-option soft-wrap.enable" ];
+    C-q = [ ":buffer-close" ];
     A-ret = [ ":run-shell-command basename $(pwd)" ];
     C-ret = [
       ":run-shell-command echo \"%sh{git blame -L %{cursor_line},+1 %{buffer_name} | cut -d' ' -f1-8}\""
     ];
-    A-g = ":run-shell-command git difftool -d";
-    A-space = ":run-shell-command echo -n \"%{buffer_name}\" | sed \"s@~/@@g\" | sed \"s@$PWD@@g\" | wl-copy && echo \"Path copied!\"";
+    # A-g = ":run-shell-command git difftool -d";
+    A-g = [ ":run-shell-command code --disable-extensions ." ];
+    A-space = [
+      ":run-shell-command echo -n \"%{buffer_name}\" | sed \"s@~/@@g\" | sed \"s@$PWD@@g\" | wl-copy"
+      ":run-shell-command echo \"Path copied!\""
+    ];
   };
   select = { };
 }


### PR DESCRIPTION
Convert single command keybindings to lists for consistency.
Change `A-g` to open VS Code. Split `A-space` commands.
