### PR TITLE
feat(helix): add sonarlint language server

### DIFF
--- a/home-manager/src/configs/helix/langs.nix
+++ b/home-manager/src/configs/helix/langs.nix
@@ -3,7 +3,7 @@
   global = {
     lsp = [
       "scls"
-      "helix-gpt"
+      # "helix-gpt"
       "typos"
     ];
   };
@@ -34,4 +34,5 @@
   fish = true;
   prisma = true;
   typos = true;
+  sonarlint = true;
 }

--- a/home-manager/src/configs/helix/langs/go/default.nix
+++ b/home-manager/src/configs/helix/langs/go/default.nix
@@ -42,7 +42,10 @@ lib.mkIf (isEnable) {
           start = "/*";
           end = "*/";
         };
-        language-servers = [ "gopls" ] ++ langs.global.lsp;
+        language-servers = [
+          "gopls"
+          "sonarlint"
+        ] ++ langs.global.lsp;
         indent = {
           tab-width = 2;
           unit = " ";

--- a/home-manager/src/configs/helix/langs/sonarlint/default.nix
+++ b/home-manager/src/configs/helix/langs/sonarlint/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  langs = import ../../langs.nix { };
+  isEnable = langs.sonarlint;
+in
+lib.mkIf (isEnable) {
+  home.packages = [
+    pkgs.sonarlint-ls
+  ];
+
+  programs.helix.languages = {
+    sonarlint = {
+      command = "sonarlint-ls";
+    };
+  };
+}


### PR DESCRIPTION
Enable sonarlint globally and for Go language configuration.
Includes setup for sonarlint-ls package and server command.
